### PR TITLE
Fix missing state in Client.authorization_url

### DIFF
--- a/microsoftgraph/client.py
+++ b/microsoftgraph/client.py
@@ -57,7 +57,7 @@ class Client(object):
         }
 
         if state:
-            params['state'] = None
+            params['state'] = state
         if self.office365:
             response = self.OFFICE365_AUTHORITY_URL + self.OFFICE365_AUTH_ENDPOINT + urlencode(params)
         else:


### PR DESCRIPTION
The state parameter in the Client.authorization_url() method was always being ignored (and substituted for None instead). Now the state parameter is included in the URL