### PR TITLE
Fix KeyError 'content-type'

### DIFF
--- a/microsoftgraph/client.py
+++ b/microsoftgraph/client.py
@@ -613,7 +613,7 @@ class Client(object):
 
     def _parse(self, response):
         status_code = response.status_code
-        if 'application/json' in response.headers['Content-Type']:
+        if 'application/json' in response.headers.get('Content-Type', ''):
             r = response.json()
         else:
             r = response.content


### PR DESCRIPTION
Some responses (like delete calendar event) don't include a Content-Type header.